### PR TITLE
chore(ci): remove custom JavaScript security queries from CodeQL config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -12,8 +12,6 @@ paths-ignore:
 queries:
   - uses: security-extended
   - uses: security-and-quality
-  - name: Custom JavaScript Security Rules
-    uses: ./.github/codeql/custom-queries/javascript
 
 query-filters:
   - exclude:


### PR DESCRIPTION
- Remove custom-queries/javascript reference from CodeQL configuration
- Retain security-extended and security-and-quality query suites


